### PR TITLE
remove the U from open since it is not needed. 

### DIFF
--- a/scripts/iu-remove-ids-from-fastq
+++ b/scripts/iu-remove-ids-from-fastq
@@ -27,7 +27,7 @@ J = os.path.join
 
 
 def main(fastq_path, ids_path, delimiter=None):
-    ids = set([id.strip() for id in open(ids_path, 'rU')])
+    ids = set([id.strip() for id in open(ids_path, 'r')])
     input = u.FastQSource(fastq_path)
 
 


### PR DESCRIPTION
See https://softwareengineering.stackexchange.com/questions/298677/why-is-universal-newlines-mode-deprecated-in-python/298685#298685 for more details
